### PR TITLE
Handle confirmAddress and predictHousingType intents.

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -1,15 +1,23 @@
-import { geoSearch } from "@justfixnyc/geosearch-requester/commonjs";
+import { geoSearch, GeoSearchResults } from "@justfixnyc/geosearch-requester/commonjs";
 import fetch from "node-fetch";
+
+
+export type DialogFlowLocation = {
+    'business-name': string,
+    'street-address': string,
+    'subadmin-area': string,
+    'city': string,
+    'zip-code': string
+}
 
 export type DialogflowWebhookRequest = {
   queryResult: {
     queryText: string;
     parameters: {
-      location: {
-        'business-name': string,
-        'street-address': string,
-        'subadmin-area': string,
-      }
+      location: DialogFlowLocation
+    };
+    intent: {
+      displayName: string
     }
   }
 };
@@ -30,7 +38,7 @@ function splitBBL(bbl: string) {
   return { boro, block, lot };
 }
 
-async function getLandlordInfo(bbl: string): Promise<SearchResults> {
+async function fetchLandlordInfo(bbl: string): Promise<SearchResults> {
   const url = new URL('https://wow-django.herokuapp.com/api/address');
   const params = splitBBL(bbl);
   url.searchParams.append('borough', params.boro);
@@ -93,23 +101,35 @@ type SearchResults = {
   geosearch?: GeoSearchData;
 };
 
-export async function handleRequest(dfReq: DialogflowWebhookRequest): Promise<DialogflowWebhookResponse> {
-  const loc = dfReq.queryResult.parameters.location;
-  let addr = loc["street-address"] || loc['business-name'];
-  if (loc['subadmin-area']) {
-    addr += ', ' + loc['subadmin-area'];
+function classifyIntent(intentDisplayName: string): string {
+  if (intentDisplayName.includes('ConfirmAddress')) {
+    return 'confirm-address';
+  } else if (intentDisplayName.includes('HousingType')) {
+    return 'predict-housing-type';
+  } else {
+    return 'get-landlord-info';
   }
-  const geoResult = await geoSearch(addr, {
-    fetch: fetch as any
-  });
+}
 
+function formatAddress(location: DialogFlowLocation): string {
+  let addr = location["street-address"] || location['business-name'];
+  if (location['subadmin-area']) {
+    addr += ', ' + location['subadmin-area'];
+  }
+  if (location['zip-code']) {
+    addr += ', ' + location['zip-code'];
+  }
+  return addr;
+}
+
+async function getLandlordInfoResponse(geoResult: GeoSearchResults): Promise<string> {
   let text = "Unfortunately, I was unable to find any information about the landlord at that address.";
 
   if (geoResult.features.length > 0) {
     const feature = geoResult.features[0];
     const bbl = feature.properties.pad_bbl;
     const addr = `${feature.properties.name}, ${feature.properties.borough}`;
-    const landlord = await getLandlordInfo(bbl);
+    const landlord = await fetchLandlordInfo(bbl);
 
     if (landlord.addrs.length === 0) {
       text = `Alas, I couldn't find any information about the landlord at ${addr}.`;
@@ -122,11 +142,73 @@ export async function handleRequest(dfReq: DialogflowWebhookRequest): Promise<Di
       text += ` Learn more at https://whoownswhat.justfix.nyc/bbl/${bbl}.`;
     }
   }
+  return text;
+}
+
+function confirmAddressResponse(geoResult: GeoSearchResults): string {
+  let text = "I couldn't find that address. Can you tell me your full street address (no apartment number), borough, and zip? e.g. '150 Court St, Brooklyn, 11201'";
+  if (geoResult.features.length > 0) {
+    const feature = geoResult.features[0];
+    const addr = `${feature.properties.name}, ${feature.properties.borough}`;
+    text = `I found ${addr}. Is that right?`
+  }
+  return text;
+}
+
+async function predictHousingTypeResponse(geoResult: GeoSearchResults): Promise<string> {
+  let text = "It doesn't look like your building has any rent regulated units.";
+  // set to market rate as default?
+  if (geoResult.features.length > 0) {
+    const feature = geoResult.features[0];
+    const bbl = feature.properties.pad_bbl;
+    const addr = `${feature.properties.name}, ${feature.properties.borough}`;
+    const predictedHousingType = await predictHousingType(bbl);
+    text = `Looks like you might live in ${predictedHousingType}`;
+    // make sure to also set follow up intent so it goes to the correct housing type intent.
+  }
+  return text;
+}
+
+
+export async function handleRequest(dfReq: DialogflowWebhookRequest): Promise<DialogflowWebhookResponse> {
+  console.log(dfReq.queryResult);
+
+  const loc = dfReq.queryResult.parameters.location;
+  let addr = formatAddress(loc);
+  const geoResult = await geoSearch(addr, {
+    fetch: fetch as any
+  });
+
+  let responseText = '';
+  switch(classifyIntent(dfReq.queryResult.intent.displayName)) {
+    case 'confirm-address':
+      responseText = confirmAddressResponse(geoResult);
+      break;
+    case 'predict-housing-type':
+      predictHousingTypeResponse(geoResult).then(
+        res => {
+          responseText = res;
+        }
+      );
+      break;
+    case 'get-landlord-info':
+      getLandlordInfoResponse(geoResult).then(
+        res => {
+          responseText = res;
+        }
+      );
+      break;
+    default:
+      responseText = "I don't know how to handle this yet";
+      break;
+  }
+
+
 
   const dfRes: DialogflowWebhookResponse = {
     fulfillmentMessages: [{
       text: {
-        text: [text],
+        text: [responseText],
       }
     }]
   };

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import bodyParser from "body-parser";
 import { DialogflowWebhookResponse, handleRequest } from "./handler";
 
-const PORT = process.env['PORT'] || '3000';
+const PORT = process.env['PORT'] || '3001';
 
 const app = express();
 

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,7 @@ import express from "express";
 import bodyParser from "body-parser";
 import { DialogflowWebhookResponse, handleRequest } from "./handler";
 
-const PORT = process.env['PORT'] || '3001';
+const PORT = process.env['PORT'] || '3000';
 
 const app = express();
 


### PR DESCRIPTION
This is a draft PR that lays out the structure for the server. it allows the server to respond to the confirmAddress and the predictHousingType intents.

WOW still needs to be swapped out for a direct connection to NYCDB.

To run dialogflow project, open 4 tabs

~/justfix/git/dialogflow-fun (branch*) $ node server.js
~/justfix/git/dialogflow-fun (branch*) $ yarn && yarn watch
~/justfix/git/dialogflow-fun (branch*) $ ./ngrok http 3000
And also anytime you quit ngrok when you re-launch it you have to change the url at https://dialogflow.cloud.google.com/#/agent/main-analog-315620/fulfillment to the new ngrok link
One for just interacting with git
[ch7330] [ch7273]